### PR TITLE
Refactor frontend flows and add dashboard APIs

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -215,6 +215,64 @@ function apiVersionServer() {
   return { ok: true, version: WEBAPP_VERSION, ts: new Date().toISOString() };
 }
 
+function apiDashboardServer(pin) {
+  try {
+    if (!pin) {
+      return { ok: false, code: 'PIN_REQUIRED', message: 'PIN obrigatório' };
+    }
+    if (!Services || typeof Services.dashboard !== 'function') {
+      return { ok: false, code: 'MISSING_SERVICE', message: 'Services.dashboard não encontrado.' };
+    }
+    const session = Services.validarPIN(pin);
+    if (!session || session.ok !== true) {
+      return { ok: false, code: 'SESSION_INVALID', message: 'PIN inválido ou inativo.' };
+    }
+    return Services.dashboard({});
+  } catch (e) {
+    Logger.log('[apiDashboardServer][EXCEPTION] %s\n%s', e && e.message, e && e.stack);
+    return { ok: false, code: 'EXCEPTION', message: String(e && e.message || e) };
+  }
+}
+
+function apiDashboardPessoalServer(pin) {
+  try {
+    if (!pin) {
+      return { ok: false, code: 'PIN_REQUIRED', message: 'PIN obrigatório' };
+    }
+    if (!Services || typeof Services.dashboardPessoal !== 'function') {
+      return { ok: false, code: 'MISSING_SERVICE', message: 'Services.dashboardPessoal não encontrado.' };
+    }
+    const session = Services.validarPIN(pin);
+    if (!session || session.ok !== true) {
+      return { ok: false, code: 'SESSION_INVALID', message: 'PIN inválido ou inativo.' };
+    }
+    return Services.dashboardPessoal(pin, session.nome || '');
+  } catch (e) {
+    Logger.log('[apiDashboardPessoalServer][EXCEPTION] %s\n%s', e && e.message, e && e.stack);
+    return { ok: false, code: 'EXCEPTION', message: String(e && e.message || e) };
+  }
+}
+
+function apiMinhasAtividadesServer(tipo, pin) {
+  try {
+    if (!pin) {
+      return { ok: false, code: 'PIN_REQUIRED', message: 'PIN obrigatório' };
+    }
+    if (!Services || typeof Services.minhasAtividades !== 'function') {
+      return { ok: false, code: 'MISSING_SERVICE', message: 'Services.minhasAtividades não encontrado.' };
+    }
+    const session = Services.validarPIN(pin);
+    if (!session || session.ok !== true) {
+      return { ok: false, code: 'SESSION_INVALID', message: 'PIN inválido ou inativo.' };
+    }
+    const params = { type: tipo || 'uploads' };
+    return Services.minhasAtividades(params, pin, session.nome || '');
+  } catch (e) {
+    Logger.log('[apiMinhasAtividadesServer][EXCEPTION] %s\n%s', e && e.message, e && e.stack);
+    return { ok: false, code: 'EXCEPTION', message: String(e && e.message || e) };
+  }
+}
+
 function apiListarServer(pin) {
   try {
     if (!pin) return { ok:false, code:'PIN_REQUIRED', message:'PIN obrigatório' };

--- a/Frontend.html
+++ b/Frontend.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="pt-BR">
   <head>
     <meta charset="UTF-8">
     <base target="_top">
@@ -7,15 +7,14 @@
     <?!= include('FrontendCSS'); ?>
   </head>
   <body>
-    <div id="app">
+    <div id="app" class="page">
       <!-- Seção de login -->
-      <div id="loginSection">
+      <div id="loginSection" class="pageSection">
         <h2>Login - Informe seu PIN</h2>
         <input id="pinInput" type="text" maxlength="6" placeholder="PIN de 6 dígitos" />
-        <!-- O PIN é pré-definido na aba Users, então este botão pode ficar oculto -->
         <button id="btnGerarPin" type="button" style="display:none">Gerar Novo PIN</button>
         <button id="btnEntrar" type="button">Entrar</button>
-        <div id="loginMsg"></div>
+        <div id="loginMsg" class="msg"></div>
       </div>
 
       <!-- Menu principal -->
@@ -24,131 +23,98 @@
         <button data-section="lista">Lista</button>
         <button data-section="dashboard">Dashboard</button>
         <button data-section="atividades">Minhas Atividades</button>
-        <button id="btnLogout" type="button" style="float:right;">Sair</button>
+        <button id="btnLogout" type="button" style="margin-left:auto;">Sair</button>
       </div>
 
       <!-- Seção de Upload -->
-      <div id="uploadSection" class="pageSection" style="display:none;">
+      <div id="uploadSection" class="pageSection pageSection--content" style="display:none;">
         <h3>Enviar XML de devolução</h3>
         <p>Copie e cole o conteúdo do XML abaixo (somente um por vez nesta versão).</p>
         <textarea id="xmlText" rows="12" placeholder="Cole aqui o XML completo"></textarea>
         <br />
         <button id="btnUpload" type="button">Importar XML</button>
-        <div id="uploadMsg" style="margin-top:10px;"></div>
+        <div id="uploadMsg" class="msg" style="margin-top:10px;"></div>
       </div>
 
       <!-- Seção de Lista -->
-      <div id="listaSection" class="pageSection" style="display:none;">
+      <div id="listaSection" class="pageSection pageSection--content" style="display:none;">
         <h3>Lista de notas</h3>
         <button id="btnAtualizarLista" type="button">Atualizar Lista</button>
-        <table id="listaTable"></table>
+        <div class="table-responsive">
+          <table id="listaTable"></table>
+        </div>
       </div>
 
       <!-- Seção de Dashboard -->
-      <div id="dashboardSection" class="pageSection" style="display:none;">
+      <div id="dashboardSection" class="pageSection pageSection--content" style="display:none;">
         <h3>Dashboard Geral</h3>
-        <div id="dashboardContent"></div>
+        <div id="dashboardContent" class="dashboard-content"></div>
         <h3>Meu Dashboard</h3>
-        <div id="dashboardPessoalContent"></div>
+        <div id="dashboardPessoalContent" class="dashboard-content"></div>
       </div>
 
       <!-- Seção de Minhas Atividades -->
-      <div id="atividadesSection" class="pageSection" style="display:none;">
+      <div id="atividadesSection" class="pageSection pageSection--content" style="display:none;">
         <h3>Minhas Atividades</h3>
-        <button data-type="uploads" type="button">Meus Uploads</button>
-        <button data-type="validacoes" type="button">Minhas Validações</button>
-        <table id="atividadesTable"></table>
+        <div class="atividades-actions">
+          <button data-type="uploads" type="button">Meus Uploads</button>
+          <button data-type="validacoes" type="button">Minhas Validações</button>
+        </div>
+        <div id="atividadesMsg" class="msg"></div>
+        <div class="table-responsive">
+          <table id="atividadesTable"></table>
+        </div>
+      </div>
+
+      <!-- Detalhe / Validação -->
+      <div id="detalheSection" class="pageSection pageSection--content" style="display:none;">
+        <h3>Detalhe da Nota</h3>
+        <div id="detalheInfo"></div>
+
+        <div style="margin:10px 0;">
+          <label><input type="radio" name="statusNota" value="Aceita"> Aceitar nota</label>
+          <label style="margin-left:12px;"><input type="radio" name="statusNota" value="Recusada"> Recusar nota</label>
+        </div>
+
+        <div id="pagamentoBox" style="display:none;">
+          <label>Forma de pagamento:
+            <select id="formaPagamento">
+              <option value="">Selecione</option>
+              <option>Pix</option>
+              <option>Depósito</option>
+              <option>Dinheiro</option>
+              <option>Crédito</option>
+              <option>Outros</option>
+            </select>
+          </label>
+          <label style="margin-left:8px;">Data pagamento:
+            <input type="date" id="dataPagamento">
+          </label>
+        </div>
+
+        <label>Observações da nota:
+          <input id="obsNota" type="text" placeholder="(obrigatório se Recusada)">
+        </label>
+
+        <h4>Itens</h4>
+        <div class="table-responsive">
+          <table id="itensTable">
+            <tr>
+              <th>Seq</th><th>Código</th><th>Descrição</th><th>Qtd</th>
+              <th>Status</th><th>Motivo</th><th>Qtde Devolvida</th><th>Obs</th>
+            </tr>
+          </table>
+        </div>
+
+        <div style="margin-top:12px;">
+          <button id="btnSalvarValidacao" type="button">Salvar validação</button>
+          <button id="btnVoltarLista" type="button">Voltar</button>
+        </div>
+        <div id="detalheMsg" class="msg" style="margin-top:8px;"></div>
       </div>
     </div>
 
-
-<!-- Detalhe / Validação -->
-<div id="detalheSection" class="pageSection" style="display:none;">
-  <h3>Detalhe da Nota</h3>
-  <div id="detalheInfo"></div>
-
-  <div style="margin:10px 0;">
-    <label><input type="radio" name="statusNota" value="Aceita"> Aceitar nota</label>
-    <label style="margin-left:12px;"><input type="radio" name="statusNota" value="Recusada"> Recusar nota</label>
-  </div>
-
-  <div id="pagamentoBox" style="display:none;">
-    <label>Forma de pagamento:
-      <select id="formaPagamento">
-        <option value="">Selecione</option>
-        <option>Pix</option><option>Depósito</option><option>Dinheiro</option><option>Crédito</option><option>Outros</option>
-      </select>
-    </label>
-    <label style="margin-left:8px;">Data pagamento:
-      <input type="date" id="dataPagamento">
-    </label>
-  </div>
-
-  <label>Observações da nota:
-    <input id="obsNota" type="text" placeholder="(obrigatório se Recusada)">
-  </label>
-
-  <h4>Itens</h4>
-  <table id="itensTable">
-    <tr>
-      <th>Seq</th><th>Código</th><th>Descrição</th><th>Qtd</th>
-      <th>Status</th><th>Motivo</th><th>Qtde Devolvida</th><th>Obs</th>
-    </tr>
-  </table>
-
-  <div style="margin-top:12px;">
-    <button id="btnSalvarValidacao" type="button">Salvar validação</button>
-    <button id="btnVoltarLista" type="button">Voltar</button>
-  </div>
-  <div id="detalheMsg" style="margin-top:8px;"></div>
-</div>
-
-
-
-<!-- Modal/Seção de Detalhe -->
-<div id="detalheSection" class="pageSection" style="display:none;">
-  <h3>Detalhe da Nota</h3>
-  <div id="detalheInfo"></div>
-
-  <!-- status da NOTA -->
-  <div style="margin:10px 0;">
-    <label><input type="radio" name="statusNota" value="Aceita"> Aceitar nota</label>
-    <label style="margin-left:12px;"><input type="radio" name="statusNota" value="Recusada"> Recusar nota</label>
-  </div>
-
-  <!-- campos extras (só se Aceita) -->
-  <div id="pagamentoBox" style="display:none;">
-    <label>Forma de pagamento:
-      <select id="formaPagamento">
-        <option value="">Selecione</option>
-        <option>Pix</option><option>Depósito</option><option>Dinheiro</option><option>Crédito</option><option>Outros</option>
-      </select>
-    </label>
-    <label style="margin-left:8px;">Data pagamento: <input type="date" id="dataPagamento"></label>
-    <br/>
-  </div>
-
-  <label>Observações da nota:
-    <input id="obsNota" type="text" placeholder="(obrigatório se Recusada)">
-  </label>
-
-  <h4>Itens</h4>
-  <table id="itensTable">
-    <tr>
-      <th>Seq</th><th>Código</th><th>Descrição</th><th>Qtd</th><th>Status</th><th>Motivo</th><th>Qtde Devolvida</th><th>Obs</th>
-    </tr>
-    <!-- linhas geradas via JS -->
-  </table>
-
-  <div style="margin-top:12px;">
-    <button id="btnSalvarValidacao" type="button">Salvar validação</button>
-    <button id="btnVoltarLista" type="button">Voltar</button>
-  </div>
-  <div id="detalheMsg" style="margin-top:8px;"></div>
-</div>
-
-
+    <?!= HtmlService.createHtmlOutputFromFile('FrontendDashJS').getContent(); ?>
     <?!= HtmlService.createHtmlOutputFromFile('FrontendJS').getContent(); ?>
-
   </body>
 </html>

--- a/FrontendCSS.html
+++ b/FrontendCSS.html
@@ -52,6 +52,8 @@ h2,h3{margin: 12px 0 8px;color:var(--txt)}
   border-radius: var(--radius);
   box-shadow: var(--shadow);
 }
+.pageSection--content h3:first-child{margin-top:0}
+.pageSection--content p{margin-top:0}
 
 /* Botões */
 button, .btn{
@@ -91,8 +93,8 @@ textarea{resize:vertical; min-height: 90px}
 
 /* Alertas / mensagens */
 .msg{margin-top:8px; font-size:.9rem}
-.msg--error{color:#d32f2f}
-.msg--ok{color:#2e7d32}
+.err{color:#d32f2f}
+.ok{color:#2e7d32}
 
 /* Tabelas: modo desktop padrão + 2 opções de responsividade */
 
@@ -113,6 +115,7 @@ table{
   min-width: 700px; /* ajuda a não “achatar” demais no desktop */
   background: white;
 }
+.dashboard-table{min-width:unset}
 th, td{
   border-bottom: 1px solid #eee;
   padding: 10px;
@@ -155,6 +158,9 @@ th{
   align-items:center;
   padding: 8px 0;
 }
+
+.dashboard-content{margin-bottom:24px}
+.atividades-actions{display:flex; gap:8px; flex-wrap:wrap; margin-bottom:12px}
 
 /* Acessibilidade e preferências */
 @media (prefers-reduced-motion: reduce){

--- a/FrontendDashJS.html
+++ b/FrontendDashJS.html
@@ -1,68 +1,45 @@
-// Robust front‑end script for the Devoluções NFe dashboard.
-// This script should be included in your FrontendJS.html file via
-// <?!= HtmlService.createHtmlOutputFromFile('robust_frontend').getContent(); ?>
-// It uses Chart.js (loaded dynamically) to render charts and builds
-// a more featureful dashboard.
-
+<script>
 (() => {
-  /**
-   * Loads the Chart.js library if it is not already loaded. Returns a Promise
-   * that resolves when Chart.js is ready.
-   */
-  function loadChartJs() {
-    return new Promise((resolve) => {
-      if (window.Chart) {
-        resolve();
-        return;
-      }
-      const script = document.createElement('script');
-      script.src = 'https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.3.0/chart.umd.min.js';
-      script.onload = () => resolve();
-      document.head.appendChild(script);
-    });
-  }
+  let chartPromise;
 
-  /**
-   * Formats a number as Brazilian Real currency string.
-   * @param {number} value
-   */
-  function formatCurrency(value) {
-    return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
-  }
-
-  /**
-   * Creates or updates a Chart.js chart.
-   * @param {HTMLCanvasElement} canvas
-   * @param {string} type
-   * @param {object} data
-   * @param {object} options
-   */
-  function renderChart(canvas, type, data, options = {}) {
-    // If a chart instance already exists on this canvas, destroy it first
-    if (canvas.__chart) {
-      canvas.__chart.destroy();
+  function ensureChartJs() {
+    if (!chartPromise) {
+      chartPromise = new Promise((resolve) => {
+        if (window.Chart) {
+          resolve();
+          return;
+        }
+        const script = document.createElement('script');
+        script.src = 'https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.3.0/chart.umd.min.js';
+        script.onload = () => resolve();
+        script.onerror = () => resolve();
+        document.head.appendChild(script);
+      });
     }
-    const ctx = canvas.getContext('2d');
-    const chart = new Chart(ctx, {
-      type,
-      data,
-      options,
-    });
-    canvas.__chart = chart;
+    return chartPromise;
   }
 
-  /**
-   * Renders the general dashboard into the provided container element.
-   * @param {Element} container
-   * @param {object} data
-   */
+  function runServer(method, ...args) {
+    return new Promise((resolve, reject) => {
+      google.script.run
+        .withSuccessHandler(resolve)
+        .withFailureHandler(reject)[method](...args);
+    });
+  }
+
+  function formatCurrency(value) {
+    const number = Number(value) || 0;
+    return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(number);
+  }
+
   function renderDashboard(container, data) {
+    if (!container) return;
     container.innerHTML = '';
     if (!data || !data.ok) {
       container.textContent = data && data.message ? data.message : 'Erro ao carregar o dashboard.';
       return;
     }
-    // Summary table
+
     const summarySection = document.createElement('div');
     summarySection.innerHTML = '<h4>Resumo geral</h4>';
     const summaryTable = document.createElement('table');
@@ -76,80 +53,72 @@
     summarySection.appendChild(summaryTable);
     container.appendChild(summarySection);
 
-    // Reasons chart
     const reasonsSection = document.createElement('div');
     reasonsSection.innerHTML = '<h4>Motivos de recusa</h4>';
     const reasonsCanvas = document.createElement('canvas');
     reasonsSection.appendChild(reasonsCanvas);
     container.appendChild(reasonsSection);
-    const reasonsLabels = Object.keys(data.reasons);
+    const reasonsLabels = Object.keys(data.reasons || {});
     const reasonsValues = reasonsLabels.map((k) => data.reasons[k]);
-    renderChart(reasonsCanvas, 'pie', {
-      labels: reasonsLabels,
-      datasets: [{ data: reasonsValues }],
-    }, { plugins: { legend: { position: 'right' } }, responsive: true, maintainAspectRatio: false });
+    if (reasonsLabels.length) {
+      renderChart(reasonsCanvas, 'pie', {
+        labels: reasonsLabels,
+        datasets: [{ data: reasonsValues }],
+      }, { plugins: { legend: { position: 'right' } }, responsive: true, maintainAspectRatio: false });
+    } else {
+      reasonsSection.textContent = 'Sem recusas registradas.';
+    }
 
-    // Daily uploads chart
     const dailySection = document.createElement('div');
     dailySection.innerHTML = '<h4>Uploads diários</h4>';
     const dailyCanvas = document.createElement('canvas');
     dailySection.appendChild(dailyCanvas);
     container.appendChild(dailySection);
-    const dailyLabels = data.dailyUploads.map((d) => d.date);
-    const dailyCounts = data.dailyUploads.map((d) => d.count);
+    const dailyLabels = (data.dailyUploads || []).map((d) => d.date);
+    const dailyCounts = (data.dailyUploads || []).map((d) => d.count);
     renderChart(dailyCanvas, 'bar', {
       labels: dailyLabels,
       datasets: [{ label: 'Notas importadas', data: dailyCounts }],
     }, { scales: { x: { ticks: { autoSkip: true, maxTicksLimit: 7 } } } });
 
-    // Productivity chart
     const prodSection = document.createElement('div');
     prodSection.innerHTML = '<h4>Produtividade por usuário</h4>';
     const prodCanvas = document.createElement('canvas');
     prodSection.appendChild(prodCanvas);
     container.appendChild(prodSection);
-    const prodUsers = [];
-    const prodCounts = [];
-    data.productivity.created.forEach((u) => {
-      prodUsers.push(u.user);
-      prodCounts.push(u.count);
-    });
+    const prodUsers = (data.productivity?.created || []).map((u) => u.user);
+    const prodCounts = (data.productivity?.created || []).map((u) => u.count);
     renderChart(prodCanvas, 'bar', {
       labels: prodUsers,
       datasets: [{ label: 'Notas criadas', data: prodCounts }],
     }, { scales: { x: { ticks: { autoSkip: false } } }, plugins: { legend: { display: false } } });
 
-    // Last activities table
     const lastSection = document.createElement('div');
     lastSection.innerHTML = '<h4>Últimas notas</h4>';
     const lastTable = document.createElement('table');
     lastTable.className = 'dashboard-table';
     lastTable.innerHTML = '<tr><th>Data</th><th>Chave</th><th>Status</th><th>Valor</th><th>Criado por</th></tr>';
-    data.lastActivities.forEach((act) => {
+    (data.lastActivities || []).forEach((act) => {
       const row = document.createElement('tr');
       row.innerHTML = `<td>${(act.criadoEm || '').slice(0, 10)}</td>` +
-                      `<td>${act.chave}</td>` +
-                      `<td>${act.status}</td>` +
+                      `<td>${act.chave || ''}</td>` +
+                      `<td>${act.status || ''}</td>` +
                       `<td>${formatCurrency(act.valor)}</td>` +
-                      `<td>${act.criadoPor}</td>`;
+                      `<td>${act.criadoPor || ''}</td>`;
       lastTable.appendChild(row);
     });
     lastSection.appendChild(lastTable);
     container.appendChild(lastSection);
   }
 
-  /**
-   * Renders the personal dashboard into the provided container element.
-   * @param {Element} container
-   * @param {object} data
-   */
   function renderPersonalDashboard(container, data) {
+    if (!container) return;
     container.innerHTML = '';
     if (!data || !data.ok) {
       container.textContent = data && data.message ? data.message : 'Erro ao carregar seu dashboard.';
       return;
     }
-    // Summary
+
     const summarySection = document.createElement('div');
     summarySection.innerHTML = '<h4>Meu resumo</h4>';
     const summaryTable = document.createElement('table');
@@ -163,32 +132,28 @@
     summarySection.appendChild(summaryTable);
     container.appendChild(summarySection);
 
-    // Reasons chart (if any)
-    if (Object.keys(data.reasons).length > 0) {
+    if (Object.keys(data.reasons || {}).length > 0) {
       const reasonsSection = document.createElement('div');
       reasonsSection.innerHTML = '<h4>Meus motivos de recusa</h4>';
       const reasonsCanvas = document.createElement('canvas');
       reasonsSection.appendChild(reasonsCanvas);
       container.appendChild(reasonsSection);
-      const reasonsLabels = Object.keys(data.reasons);
-      const reasonsValues = reasonsLabels.map((k) => data.reasons[k]);
       renderChart(reasonsCanvas, 'pie', {
-        labels: reasonsLabels,
-        datasets: [{ data: reasonsValues }],
+        labels: Object.keys(data.reasons),
+        datasets: [{ data: Object.values(data.reasons) }],
       }, { plugins: { legend: { position: 'right' } }, responsive: true, maintainAspectRatio: false });
     }
 
-    // Last activities
     const lastSection = document.createElement('div');
     lastSection.innerHTML = '<h4>Minhas últimas notas</h4>';
     const lastTable = document.createElement('table');
     lastTable.className = 'dashboard-table';
     lastTable.innerHTML = '<tr><th>Data</th><th>Chave</th><th>Status</th><th>Valor</th></tr>';
-    data.lastActivities.forEach((act) => {
+    (data.lastActivities || []).forEach((act) => {
       const row = document.createElement('tr');
       row.innerHTML = `<td>${(act.criadoEm || '').slice(0, 10)}</td>` +
-                      `<td>${act.chave}</td>` +
-                      `<td>${act.status}</td>` +
+                      `<td>${act.chave || ''}</td>` +
+                      `<td>${act.status || ''}</td>` +
                       `<td>${formatCurrency(act.valor)}</td>`;
       lastTable.appendChild(row);
     });
@@ -196,32 +161,53 @@
     container.appendChild(lastSection);
   }
 
-  /**
-   * Fetches dashboard data from the server and renders it.
-   */
-  function loadDashboards() {
-    const geralContainer = document.getElementById('dashboardContent');
-    const pessoalContainer = document.getElementById('dashboardPessoalContent');
-    // Carrega dashboard geral
-    google.script.run
-      .withSuccessHandler((data) => renderDashboard(geralContainer, data))
-      .withFailureHandler((err) => {
-        geralContainer.textContent = 'Erro de conexão no dashboard geral.';
-        console.error(err);
-      })
-      .dashboard();
-    // Carrega dashboard pessoal
-    google.script.run
-      .withSuccessHandler((data) => renderPersonalDashboard(pessoalContainer, data))
-      .withFailureHandler((err) => {
-        pessoalContainer.textContent = 'Erro de conexão no dashboard pessoal.';
-        console.error(err);
-      })
-      .dashboardPessoal();
+  function renderChart(canvas, type, data, options = {}) {
+    if (!canvas) return;
+    if (canvas.__chart) {
+      canvas.__chart.destroy();
+    }
+    const ctx = canvas.getContext('2d');
+    canvas.__chart = new Chart(ctx, { type, data, options });
   }
 
-  // Inicializa quando a página estiver pronta
+  async function loadDashboardsInternal() {
+    const geralContainer = document.getElementById('dashboardContent');
+    const pessoalContainer = document.getElementById('dashboardPessoalContent');
+    if (!geralContainer || !pessoalContainer) return;
+
+    const pin = sessionStorage.getItem('userPin') || '';
+    if (!pin) {
+      geralContainer.textContent = 'Faça login para ver o dashboard.';
+      pessoalContainer.textContent = 'Faça login para ver o dashboard.';
+      return;
+    }
+
+    geralContainer.textContent = 'Carregando...';
+    pessoalContainer.textContent = 'Carregando...';
+
+    try {
+      await ensureChartJs();
+      const [geralData, pessoalData] = await Promise.all([
+        runServer('apiDashboardServer', pin),
+        runServer('apiDashboardPessoalServer', pin)
+      ]);
+      renderDashboard(geralContainer, geralData);
+      renderPersonalDashboard(pessoalContainer, pessoalData);
+    } catch (err) {
+      console.error('loadDashboards error', err);
+      geralContainer.textContent = 'Falha ao carregar dashboard.';
+      pessoalContainer.textContent = 'Falha ao carregar dashboard.';
+    }
+  }
+
+  window.loadDashboards = function () {
+    loadDashboardsInternal();
+  };
+
   document.addEventListener('DOMContentLoaded', () => {
-    loadChartJs().then(loadDashboards);
+    if (sessionStorage.getItem('userPin')) {
+      loadDashboardsInternal();
+    }
   });
 })();
+</script>

--- a/FrontendJS.html
+++ b/FrontendJS.html
@@ -3,9 +3,15 @@
   // ---------- Utils ----------
   function $(sel){ return document.querySelector(sel); }
   function $all(sel){ return Array.from(document.querySelectorAll(sel)); }
-  function setMsg(el, text, cls){ if(!el) return; el.textContent = text || ''; el.className = cls || ''; }
+  function setMsg(el, text, cls){
+    if(!el) return;
+    el.textContent = text || '';
+    el.className = 'msg' + (cls ? ' ' + cls : '');
+  }
   function getPIN(){ return sessionStorage.getItem('userPin') || ''; }
   function setUser(pin, nome){ sessionStorage.setItem('userPin', pin||''); sessionStorage.setItem('userNome', nome||''); }
+
+  let atividadesTipoAtual = 'uploads';
 
   function showOnly(sectionId){
     $all('.pageSection').forEach(s => s.style.display = 'none');
@@ -141,100 +147,97 @@
 
   // ---------- DETALHE ----------
   function abrirDetalhe(id){
-  const pin = getPIN();
-  const sec = $('#detalheSection');
-  const msg = $('#detalheMsg');
+    const pin = getPIN();
+    const sec = $('#detalheSection');
+    const msg = $('#detalheMsg');
 
-  if (!id) { alert('ID vazio para detalhar.'); return; }
+    if (!id) { alert('ID vazio para detalhar.'); return; }
+    if (!pin) { alert('Sessão expirada. Faça login novamente.'); return; }
 
-  // prepara e MOSTRA a tela de detalhe antes da chamada
-  if (sec) sec.dataset.id = id;
-  $('#detalheInfo').innerHTML = '';
-  $('#itensTable').innerHTML = '';
-  document.getElementsByName('statusNota').forEach?.(r => r.checked = false);
-  const pg = $('#pagamentoBox'); if (pg) pg.style.display = 'none';
-  const obs = $('#obsNota'); if (obs) obs.value = '';
-  showOnly('detalheSection');
-  setMsg(msg, 'Carregando...', '');
-console.log('Detalhar ID →', id);
-console.log('Detalhar Pin →', pin);
-  google.script.run
-    .withSuccessHandler(function (data) {
-      console.log('apiDetalharServer →', data); // <— log completo
+    if (sec) sec.dataset.id = id;
+    const info = $('#detalheInfo'); if (info) info.innerHTML = '';
+    const itensTable = $('#itensTable');
+    if (itensTable) itensTable.innerHTML = '<tr><th>Seq</th><th>Código</th><th>Descrição</th><th>Qtd</th><th>Status</th><th>Motivo</th><th>Qtde Devolvida</th><th>Obs</th></tr>';
+    Array.from(document.getElementsByName('statusNota')).forEach(r => { r.checked = false; });
+    const pg = $('#pagamentoBox'); if (pg) pg.style.display = 'none';
+    const obs = $('#obsNota'); if (obs) obs.value = '';
+    showOnly('detalheSection');
+    setMsg(msg, 'Carregando...', '');
 
-if (!(data && data.ok)) {
-  const errTxt = data
-    ? ((data.code ? `[${data.code}] ` : '') + (data.message || 'Falha ao detalhar'))
-    : 'Falha ao detalhar (resposta nula)';
-  setMsg(msg, errTxt, 'err');
-  console.error('Detalhar FAIL →', data);
-  return;
-}
+    google.script.run
+      .withSuccessHandler(function (data) {
+        if (!(data && data.ok)) {
+          const errTxt = data
+            ? ((data.code ? `[${data.code}] ` : '') + (data.message || 'Falha ao detalhar'))
+            : 'Falha ao detalhar (resposta nula)';
+          setMsg(msg, errTxt, 'err');
+          console.error('Detalhar FAIL →', data);
+          return;
+        }
 
-      const b = data.base || {};
-      $('#detalheInfo').innerHTML =
-        `<b>Chave:</b> ${b.ChaveNFe||''} &nbsp; <b>Nº:</b> ${b.Numero||''} &nbsp; <b>Série:</b> ${b.Serie||''}
-         <br><b>Emitente:</b> ${b.Emitente_Nome||''} &nbsp; <b>Dest:</b> ${b.Destinatario_Nome||''}
-         <br><b>CFOP:</b> ${b.CFOP||''} &nbsp; <b>Valor:</b> ${b.ValorNF||''}`;
+        const b = data.base || {};
+        if (info) {
+          info.innerHTML =
+            `<b>Chave:</b> ${b.ChaveNFe||''} &nbsp; <b>Nº:</b> ${b.Numero||''} &nbsp; <b>Série:</b> ${b.Serie||''}` +
+            `<br><b>Emitente:</b> ${b.Emitente_Nome||''} &nbsp; <b>Dest:</b> ${b.Destinatario_Nome||''}` +
+            `<br><b>CFOP:</b> ${b.CFOP||''} &nbsp; <b>Valor:</b> ${b.ValorNF||''}`;
+        }
 
-      const tb = $('#itensTable');
-      tb.innerHTML = `<tr><th>Seq</th><th>Código</th><th>Descrição</th><th>Qtd</th>
-                      <th>Status</th><th>Motivo</th><th>Qtde Devolvida</th><th>Obs</th></tr>`;
+        const tb = $('#itensTable');
+        if (tb) {
+          tb.innerHTML = '<tr><th>Seq</th><th>Código</th><th>Descrição</th><th>Qtd</th><th>Status</th><th>Motivo</th><th>Qtde Devolvida</th><th>Obs</th></tr>';
+        }
 
-      const itens = data.itens || [];
-      itens.forEach(function (it) {
-        // pega seq de forma tolerante (Seq, nItem, etc.)
-        const seq = it.Seq ?? it.SEQ ?? it.nItem ?? it['nItem'] ?? it['seq'] ?? '';
-        const tr = document.createElement('tr');
-        tr.dataset.seq = seq;
-        tr.innerHTML = `
-          <td>${seq||''}</td>
-          <td>${it.Codigo||it.codigo||''}</td>
-          <td>${it.Descricao||it.descricao||''}</td>
-          <td>${it.Quantidade||it.quantidade||''}</td>
-          <td>
-            <select class="statusItem">
-              <option ${it.StatusItem==='Pendente'?'selected':''}>Pendente</option>
-              <option ${it.StatusItem==='Aceito'?'selected':''}>Aceito</option>
-              <option ${it.StatusItem==='Recusado'?'selected':''}>Recusado</option>
-            </select>
-          </td>
-          <td>
-            <select class="motivoItem">
-              <option value="">(selecione)</option>
-              <option ${it.MotivoItem==='Bolor'?'selected':''}>Bolor</option>
-              <option ${it.MotivoItem==='Shelf'?'selected':''}>Shelf</option>
-              <option ${it.MotivoItem==='Embalagem estufada'?'selected':''}>Embalagem estufada</option>
-              <option ${it.MotivoItem==='Avaria na loja'?'selected':''}>Avaria na loja</option>
-            </select>
-          </td>
-          <td><input class="qtdeDev" type="number" step="0.01" value="${it.QtdeDevolvida||''}"></td>
-          <td><input class="obsItem" type="text" value="${it.ObsItem||''}"></td>`;
-        tb.appendChild(tr);
-      });
+        const itens = data.itens || [];
+        itens.forEach(function (it) {
+          const seq = it.Seq ?? it.SEQ ?? it.nItem ?? it['nItem'] ?? it['seq'] ?? '';
+          const tr = document.createElement('tr');
+          tr.dataset.seq = seq;
+          tr.innerHTML = `
+            <td>${seq||''}</td>
+            <td>${it.Codigo||it.codigo||''}</td>
+            <td>${it.Descricao||it.descricao||''}</td>
+            <td>${it.Quantidade||it.quantidade||''}</td>
+            <td>
+              <select class="statusItem">
+                <option ${it.StatusItem==='Pendente'?'selected':''}>Pendente</option>
+                <option ${it.StatusItem==='Aceito'?'selected':''}>Aceito</option>
+                <option ${it.StatusItem==='Recusado'?'selected':''}>Recusado</option>
+              </select>
+            </td>
+            <td>
+              <select class="motivoItem">
+                <option value="">(selecione)</option>
+                <option ${it.MotivoItem==='Bolor'?'selected':''}>Bolor</option>
+                <option ${it.MotivoItem==='Shelf'?'selected':''}>Shelf</option>
+                <option ${it.MotivoItem==='Embalagem estufada'?'selected':''}>Embalagem estufada</option>
+                <option ${it.MotivoItem==='Avaria na loja'?'selected':''}>Avaria na loja</option>
+              </select>
+            </td>
+            <td><input class="qtdeDev" type="number" step="0.01" value="${it.QtdeDevolvida||''}"></td>
+            <td><input class="obsItem" type="text" value="${it.ObsItem||''}"></td>`;
+          if (tb) tb.appendChild(tr);
+        });
 
-      // Se vier 0 itens, mostra aviso útil
-      if (itens.length === 0) {
-        const baseId = (b.ID || b.Id || b.id || id);
-        setMsg(
-          msg,
-          'Nenhum item vinculado a este registro. Confirme na aba "Itens" se existe a coluna ' +
-          '"ID_RegistroBase" (ou "ID") com o valor: ' + baseId,
-          'err'
-        );
-      } else {
-        setMsg(msg, '', '');
-      }
+        if (itens.length === 0) {
+          const baseId = (b.ID || b.Id || b.id || id);
+          setMsg(
+            msg,
+            'Nenhum item vinculado a este registro. Confirme na aba "Itens" se existe a coluna "ID_RegistroBase" (ou "ID") com o valor: ' + baseId,
+            'err'
+          );
+        } else {
+          setMsg(msg, '', '');
+        }
 
-      // mantém id real enviado pelo backend (caso diferente do usado no botão)
-      if (b.ID && sec) sec.dataset.id = b.ID;
-    })
-    .withFailureHandler(function (err) {
-      console.error('apiDetalharServer FAIL →', err);
-      setMsg(msg, 'Erro de conexão', 'err');
-    })
-    .apiDetalharServer2(id, pin);
-}
+        if (b.ID && sec) sec.dataset.id = b.ID;
+      })
+      .withFailureHandler(function (err) {
+        console.error('apiDetalharServer FAIL →', err);
+        setMsg(msg, 'Erro de conexão', 'err');
+      })
+      .apiDetalharServer2(id, pin);
+  }
   // alterna pagamento quando marcar "Aceita"
   document.addEventListener('change', function (e) {
     if (e.target && e.target.name === 'statusNota') {
@@ -308,6 +311,9 @@ function bindMenu(){
       if (sectionName === 'dashboard' && typeof loadDashboards === 'function') {
         loadDashboards();
       }
+      if (sectionName === 'atividades' && typeof loadAtividades === 'function') {
+        loadAtividades(atividadesTipoAtual);
+      }
     });
   });
   const out = $('#btnLogout');
@@ -317,11 +323,71 @@ function bindMenu(){
   });
 }
 
+  function loadAtividades(tipo){
+    const pin = getPIN();
+    const msg = $('#atividadesMsg');
+    const table = $('#atividadesTable');
+    if (!pin){
+      setMsg(msg, 'Faça login primeiro.', 'err');
+      if (table) table.innerHTML = '';
+      return;
+    }
+    atividadesTipoAtual = tipo || 'uploads';
+    setMsg(msg, 'Carregando...', '');
+    if (table) table.innerHTML = '';
+
+    google.script.run
+      .withSuccessHandler(function(data){
+        if (!(data && data.ok)){
+          setMsg(msg, (data && (data.message || data.code)) || 'Falha ao carregar atividades.', 'err');
+          return;
+        }
+        const rows = data.rows || [];
+        if (rows.length === 0){
+          setMsg(msg, 'Nenhum registro encontrado.', '');
+          if (table) table.innerHTML = '';
+          return;
+        }
+        setMsg(msg, `${rows.length} registro(s) encontrado(s).`, 'ok');
+        if (table){
+          table.innerHTML = '<tr><th>Chave</th><th>Status</th><th>Valor</th><th>Criado em</th><th>Atualizado em</th></tr>';
+          rows.forEach(r => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td>${r.ChaveNFe||''}</td>` +
+              `<td>${r.Status||''}</td>` +
+              `<td>${r.ValorNF||''}</td>` +
+              `<td>${r.CriadoEm||''}</td>` +
+              `<td>${r.AtualizadoEm||''}</td>`;
+            table.appendChild(tr);
+          });
+        }
+      })
+      .withFailureHandler(function(err){
+        console.error('apiMinhasAtividadesServer FAIL →', err);
+        setMsg(msg, 'Erro de conexão ao carregar atividades.', 'err');
+      })
+      .apiMinhasAtividadesServer(atividadesTipoAtual, pin);
+  }
+
+  function bindAtividades(){
+    const section = $('#atividadesSection');
+    if (!section) return;
+    section.querySelectorAll('button[data-type]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const tipo = btn.getAttribute('data-type') || 'uploads';
+        loadAtividades(tipo);
+      });
+    });
+  }
+
+  window.loadAtividades = loadAtividades;
+
   // ---------- Bootstrap ----------
   document.addEventListener('DOMContentLoaded', function(){
     bindLogin();
     bindUpload();
     bindLista();
+    bindAtividades();
     bindMenu();
     if (getPIN()){
       const login = $('#loginSection'); if (login) login.style.display = 'none';

--- a/Tests.js
+++ b/Tests.js
@@ -14,15 +14,15 @@ function runTests() {
 
 function testParseXml() {
   const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<nfeProc>\n  <NFe>\n    <infNFe Id="NFe123" versao="4.00">\n      <ide>\n        <nNF>1</nNF>\n        <serie>1</serie>\n        <dhEmi>2025-01-01T08:30:00-03:00</dhEmi>\n      </ide>\n      <emit>\n        <CNPJ>12345678000195</CNPJ>\n        <xNome>Fornecedor Teste</xNome>\n      </emit>\n      <dest>\n        <CNPJ>98765432000100</CNPJ>\n        <xNome>Loja Teste</xNome>\n      </dest>\n      <det nItem="1">\n        <prod>\n          <cProd>XYZ</cProd>\n          <xProd>Produto Teste</xProd>\n          <NCM>1234567</NCM>\n          <CFOP>5949</CFOP>\n          <qCom>1</qCom>\n          <vUnCom>5.00</vUnCom>\n          <vProd>5.00</vProd>\n        </prod>\n      </det>\n      <total>\n        <ICMSTot>\n          <vNF>5.00</vNF>\n          <vICMS>0.00</vICMS>\n        </ICMSTot>\n      </total>\n    </infNFe>\n  </NFe>\n</nfeProc>`;
-  const result = Services.parseXml(xml);
+  const result = Services.parseXmlForTest(xml);
   Logger.log('Teste parseXml - base: %s', JSON.stringify(result.base));
   Logger.log('Itens: %s', JSON.stringify(result.itens));
 }
 
 function testSaveRecord() {
   const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<nfeProc><NFe><infNFe Id="NFeABC" versao="4.00"><ide><nNF>2</nNF><serie>1</serie><dhEmi>2025-02-01T09:00:00-03:00</dhEmi></ide><emit><CNPJ>11111111000100</CNPJ><xNome>Fornecedor 2</xNome></emit><dest><CNPJ>22222222000100</CNPJ><xNome>Destinatário 2</xNome></dest><det nItem="1"><prod><cProd>CD1</cProd><xProd>Item CD1</xProd><NCM>9876543</NCM><CFOP>5929</CFOP><qCom>3</qCom><vUnCom>2.00</vUnCom><vProd>6.00</vProd></prod></det><total><ICMSTot><vNF>6.00</vNF><vICMS>0.00</vICMS></ICMSTot></total></infNFe></NFe></nfeProc>`;
-  const parsed = Services.parseXml(xml);
-  const id = Services.saveRecord(parsed.base, parsed.itens, '999999');
+  const parsed = Services.parseXmlForTest(xml);
+  const id = Services.saveRecordForTest(parsed.base, parsed.itens, '999999');
   Logger.log('Teste saveRecord - novo ID: %s', id);
 }
 


### PR DESCRIPTION
## Summary
- rebuild the Apps Script HTML frontend with a single layout, dedicated sections, and client-side helpers for dashboards, activities, and validation flows
- add Chart.js driven dashboards that call new authenticated server wrappers for general and personal metrics
- extend Services with activity queries, safer sheet handling, and expose helpers for Tests.js

## Testing
- not run (environment lacks automated Apps Script execution)


------
https://chatgpt.com/codex/tasks/task_e_68de8ad0c7088330968fb9552b4348cf