### PR TITLE
Add pending downtime metric to list view

### DIFF
--- a/FrontendJS.html
+++ b/FrontendJS.html
@@ -127,7 +127,7 @@
             $('#recusadas').textContent = data.summary.recusadas || 0;
           }
 
-          if (table) table.innerHTML = '<tr><th>Chave</th><th>Emissão</th><th>Emitente</th><th>Valor</th><th>Status</th><th>Ação</th></tr>';
+          if (table) table.innerHTML = '<tr><th>Chave</th><th>Emissão</th><th>Emitente</th><th>Valor</th><th>Status</th><th>Tempo sem lançamento</th><th>Ação</th></tr>';
           (data.rows || []).forEach(function (r) {
             const tr = document.createElement('tr');
 
@@ -143,12 +143,24 @@
               '';
 
             const emissao = (r.Emissao instanceof Date) ? r.Emissao.toISOString() : (r.Emissao || '');
+            const status = String(r.Status || '');
+            const tempoHoras = Number(r.TempoSemLancamentoHoras);
+            let tempoDisplay = '';
+            if (status.toLowerCase() === 'pendente' && isFinite(tempoHoras) && tempoHoras >= 0) {
+              if (tempoHoras >= 24) {
+                const dias = tempoHoras / 24;
+                tempoDisplay = dias >= 1 ? `${dias.toFixed(dias >= 10 ? 0 : 1)} dia${dias >= 2 ? 's' : ''}` : '';
+              } else {
+                tempoDisplay = `${tempoHoras.toFixed(tempoHoras >= 10 ? 0 : 1)} hora${tempoHoras >= 2 ? 's' : ''}`;
+              }
+            }
             tr.innerHTML = `
               <td>${r.ChaveNFe||''}</td>
               <td>${emissao}</td>
               <td>${r.Emitente_Nome||''}</td>
               <td>${r.ValorNF||''}</td>
-              <td>${r.Status||''}</td>
+              <td>${status}</td>
+              <td>${tempoDisplay}</td>
               <td><button class="btnDetalhar" type="button" data-id="${recId}">Detalhar</button></td>`;
             table.appendChild(tr);
           });

--- a/Services.js
+++ b/Services.js
@@ -107,8 +107,31 @@ const Services = (function () {
           if (v instanceof Date) v = v.toISOString();
           r[h] = v;
         });
-        // ignora linha 100% vazia
-        if (Object.values(r).some(v => v !== '' && v !== null && v !== undefined)) rows.push(r);
+
+        const hasContent = Object.values(r).some(v => v !== '' && v !== null && v !== undefined);
+        if (!hasContent) continue;
+
+        const statusStr = String(r['Status'] || '').toLowerCase();
+        if (statusStr === 'pendente') {
+          const parseDate = (raw) => {
+            if (!raw) return null;
+            if (raw instanceof Date) return raw;
+            const d = new Date(raw);
+            return isNaN(d.getTime()) ? null : d;
+          };
+          const atual = parseDate(r['AtualizadoEm']);
+          const criado = parseDate(r['CriadoEm']);
+          const refDate = atual || criado;
+          if (refDate) {
+            const diffMs = Date.now() - refDate.getTime();
+            if (diffMs >= 0) {
+              const diffHoras = diffMs / (1000 * 60 * 60);
+              r['TempoSemLancamentoHoras'] = diffHoras;
+            }
+          }
+        }
+
+        rows.push(r);
       }
 
       // --- Filtros ---


### PR DESCRIPTION
## Summary
- compute the hours since the last update or creation for pending registros in the listar service response
- display the new "Tempo sem lançamento" column in the list, formatting the elapsed time in hours or days on the frontend

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deec397be0833089e03a58d2eda810